### PR TITLE
Fix getting records to delete

### DIFF
--- a/gurglefish/drivers/postgresql/Driver.py
+++ b/gurglefish/drivers/postgresql/Driver.py
@@ -269,7 +269,8 @@ class Driver(DbDriverMeta):
     def delete(self, cur, table_name: str, key: str):
         table_name = self.fq_table(table_name)
         try:
-            if cur.execute(f"SELECT id from {table_name} where id=%s", [key]) is None:
+            cur.execute(f"SELECT id from {table_name} where id=%s", [key])
+            if cur.fetchone() is None:
                 return 0
             cur.execute(f'delete from {table_name} where Id=%s', [key])
             return 1


### PR DESCRIPTION
cur.execute returns None, it should be executed cur.fetchone() to get records to delete.